### PR TITLE
Made it possible to parse yaml with null values

### DIFF
--- a/yaml/common.go
+++ b/yaml/common.go
@@ -24,6 +24,10 @@ func serializeToFlowStyleYaml(input interface{}) (string, error) {
 		return input.(string), nil
 	}
 
+	if inputRef.Kind() == reflect.Invalid {
+		return "", nil
+	}
+
 	var builder strings.Builder
 	encoder := yml.NewEncoder(&builder)
 	encoder.SetFlowStyle(true)

--- a/yaml/data_source_yaml_map_of_strings.go
+++ b/yaml/data_source_yaml_map_of_strings.go
@@ -71,6 +71,15 @@ func flattenValue(result map[string]string, v reflect.Value, prefix string, sepa
 	if v.Kind() == reflect.Interface {
 		v = v.Elem()
 	}
+	// For empty values we don't have anything to flatten and bail out early to
+	// prevent panic when calling v.Interface(). We still create a value in result
+	// map, but set its value to nil leaving a question how to represent null
+	// value to Terraform. From what we see, currently Terraform represents it
+	// in the same way as the empty string.
+	if v.Kind() == reflect.Invalid {
+		result[prefix] = ""
+		return nil
+	}
 
 	switch v.Kind() {
 	case reflect.Map:

--- a/yaml/data_source_yaml_map_of_strings_test.go
+++ b/yaml/data_source_yaml_map_of_strings_test.go
@@ -69,10 +69,21 @@ EOF
 }
 `
 
+const mapInputNil = `
+output "result" { value="${data.yaml_map_of_strings.doc.output}" }
+
+data "yaml_map_of_strings" "doc" {
+      input = <<EOF
+empty_key: 
+EOF
+}
+`
+
 func TestMapOfStringsDataSource(t *testing.T) {
 	flattenedOutput := map[string]string{"a/b/c": "foobar", "list": "[foo, bar]"}
 	nonFlattenedOutput := map[string]string{"a": "{b: {c: foobar}}", "list": "[foo, bar]"}
 	keyMyltiLineVal := map[string]string{"foo": "foo\nbar\nbaz\n"}
+	inputNilOutput := map[string]string{"empty_key": ""}
 
 	resource.Test(t, resource.TestCase{
 		IsUnitTest: true,
@@ -100,6 +111,12 @@ func TestMapOfStringsDataSource(t *testing.T) {
 				Config: mapInputKeyWithMultiLineString,
 				Check: resource.ComposeTestCheckFunc(
 					testMapOutputEquals("result", keyMyltiLineVal),
+				),
+			},
+			{
+				Config: mapInputNil,
+				Check: resource.ComposeTestCheckFunc(
+					testMapOutputEquals("result", inputNilOutput),
 				),
 			},
 		},


### PR DESCRIPTION
Data source "yaml_map_of_strings" with "flatten" enabled used to crash if YAML with empty keys (`key: null` or just `key:`) was passed to it.

This PR makes yaml_map_of_strings ignore these empty keys.